### PR TITLE
(INFC-17750) Prep for initial Puppet Forge Release

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,6 +3,13 @@
   delete: true
 appveyor.yml:
   delete: true
+Gemfile:
+  optional:
+    ':development':
+      - gem: 'github_changelog_generator'
+        git: 'https://github.com/skywinder/github-changelog-generator'
+        ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')"
 Rakefile:
   requires:
     - 'puppet-strings/tasks'

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development do
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "github_changelog_generator",                    require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-
 # classification
+
+![](https://img.shields.io/puppetforge/pdk-version/ploperations/classification.svg?style=popout)
+![](https://img.shields.io/puppetforge/v/ploperations/classification.svg?style=popout)
+![](https://img.shields.io/puppetforge/dt/ploperations/classification.svg?style=popout)
+[![Build Status](https://travis-ci.org/ploperations/ploperations-classification.svg?branch=master)](https://travis-ci.org/ploperations/ploperations-classification)
 
 The classification module is used internally at Puppet to do two key things:
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "ploperations-classification",
   "version": "0.1.0",
-  "author": "InfraCore at Puppet",
+  "author": "ploperations",
   "summary": "Classify nodes based on certname",
   "license": "Apache-2.0",
   "source": "https://github.com/ploperations/ploperations-classification.git",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ploperations-classification",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "ploperations",
   "summary": "Classify nodes based on certname",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Bumped to version 0.2.0 in preparation for the initial Puppet Forge release
- The use of GitHub Changelog Generator is based on https://puppet.com/blog/how-github-labels-streamline-puppet-module-release-process and notices from running `pdk bundle exec rake changelog`.
- Added badges to the readme for
  - PDK version
  - Puppet Forge version
  - Downloads
  - Travis CI
