### PR TITLE
allow digits in function

### DIFF
--- a/lib/ploperations/classification.rb
+++ b/lib/ploperations/classification.rb
@@ -23,7 +23,7 @@ module Ploperations::Classification
     version = 0
 
     case hostname
-    when %r{^([a-z0-9]*[a-z][a-z0-9]*)-([a-z]+)(-[a-z0-9]*[a-z][a-z0-9]*)?-([a-z]+)-(\d+)(-[a-z0-9]+)?$}
+    when %r{^([a-z0-9]*[a-z][a-z0-9]*)-([a-z0-9]*[a-z]+)(-[a-z0-9]*[a-z][a-z0-9]*)?-([a-z]+)-(\d+)(-[a-z0-9]+)?$}
       version = 2
       # group-function-context-stage-#-id
       group = $1

--- a/spec/functions/parse_hostname_spec.rb
+++ b/spec/functions/parse_hostname_spec.rb
@@ -3,6 +3,56 @@ require 'spec_helper'
 describe 'classification::parse_hostname' do
   on_supported_os.each do |os, _facts|
     context "on #{os}" do
+      context 'with v2 hostname with context and function contains a digit' do
+        it {
+          is_expected.to run.with_params(
+            'pe-cd4pe-infranext-prod-1',
+          ).and_return(
+            'hostname' => 'pe-cd4pe-infranext-prod-1',
+            'parts' => [
+              'pe',
+              'cd4pe',
+              '1',
+              'infranext',
+              'prod',
+              nil,
+            ],
+            'version' => 2,
+            'group' => 'pe',
+            'function' => 'cd4pe',
+            'number' => 1,
+            'number_string' => '1',
+            'context' => 'infranext',
+            'stage' => 'prod',
+            'id' => nil,
+          )
+        }
+      end
+      context 'with v2 hostname without context and function contains a digit' do
+        it {
+          is_expected.to run.with_params(
+            'pe-cd4pe-prod-1',
+          ).and_return(
+            'hostname' => 'pe-cd4pe-prod-1',
+            'parts' => [
+              'pe',
+              'cd4pe',
+              '1',
+              '',
+              'prod',
+              nil,
+            ],
+            'version' => 2,
+            'group' => 'pe',
+            'function' => 'cd4pe',
+            'number' => 1,
+            'number_string' => '1',
+            'context' => '',
+            'stage' => 'prod',
+            'id' => nil,
+          )
+        }
+      end
       context 'with v2 hostname with context' do
         it {
           is_expected.to run.with_params(


### PR DESCRIPTION
I'm taking a stab at allowing digits in the function part of the hostname, i.e:
```
pe-cd4pe-foo-bar-1
pe-cd4pe-bar-1
```
but not:
```
pe-cd4pe1-foo-bar-1
```